### PR TITLE
fix(readme): remove the `px` from the width of the images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 	<h1>
-		Hi <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="25px"> there! I'm Beatriz Sopeña Merino
+		Hi <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="25"> there! I'm Beatriz Sopeña Merino
 	</h1>
 	<h3>
 		web developer and grafic designer
@@ -13,7 +13,7 @@
 		<p>
 			Welcome to my profile!
 			<br>
-			I'm Beatriz Sopeña Merino, Fullstack web developer and grafic designer from <img src="./README/images/icons/flag-es.svg" alt="Spain" width="15px"> Madrid, Spain.
+			I'm Beatriz Sopeña Merino, Fullstack web developer and grafic designer from <img src="./README/images/icons/flag-es.svg" alt="Spain" width="15"> Madrid, Spain.
 			<br>
 			Currently, I am working from home for the <a href="https://www.webpac.com/" target="_blank" rel="noopener noreferrer">Webpac</a> company as Frontend developer, I am finishing a <a href="https://github.com/beatrizsmerino/exercises-javascript-node" target="_blank" rel="noopener noreferrer">Master of Javascript and Node JS in Fizticia</a> and working in other <a href="https://www.crcanine.com/" target="_blank" rel="noopener noreferrer">projects as a freelance</a>.
 			<br>
@@ -23,7 +23,7 @@
 	<div align="center">
 		<p>
 			<a href="https://www.linkedin.com/in/beatrizsmerino/" target="_blank" rel="noopener noreferrer">
-				<img src="./README/images/icons/linkedin.gif" alt="Beatriz`s Linkedin" width="30px"/>
+				<img src="./README/images/icons/linkedin.gif" alt="Beatriz`s Linkedin" width="30"/>
 			</a>
 		</p>
 	</div>
@@ -269,8 +269,8 @@
 		Hacktoberfest
 	</h2>
 	<p>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" width="150px"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" width="150px"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" width="150px"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" width="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" width="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" width="150"/>
 	</p>
 </div>


### PR DESCRIPTION
# fix(readme): remove the `px` from the width of the images

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P0 | S | 30-06-2022 | 30-06-2022 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" alt="Before - Images with wrong size due to px in width" src="https://user-images.githubusercontent.com/14045148/176765176-957891b5-deb0-4838-9801-efde62b6fd70.png" /> | <img width="400" alt="After - Images with correct size after removing px" src="https://user-images.githubusercontent.com/14045148/176772970-72b86d3a-eddb-4b52-9c03-e7d10cf71d23.png" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Remove `px` suffix from `width` attributes in HTML `<img>` tags across the README
- Affected images: wave GIF, Spain flag, LinkedIn icon and Hacktoberfest badges

## 📋 Changes Made

### Bug Fixes
- Remove `px` from `width="25px"` → `width="25"` (wave GIF)
- Remove `px` from `width="15px"` → `width="15"` (Spain flag)
- Remove `px` from `width="30px"` → `width="30"` (LinkedIn icon)
- Remove `px` from `width="150px"` → `width="150"` (3 Hacktoberfest badges)

## 🧪 Tests

- [x] Verify images render without `px` suffix in width attributes
- [x] Verify GIF images display at correct size on GitHub profile

## 🔗 References

### Related Issues
- Closes #1
