### PR TITLE
fix(readme): set height instead of width to align `Hacktoberfest` images

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@
 		Hacktoberfest
 	</h2>
 	<p>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" height="150"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" height="150"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" height="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" height="130"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" height="130"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" height="130"/>
 	</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@
 		Hacktoberfest
 	</h2>
 	<p>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" width="150"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" width="150"/>
-		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" width="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2019.png" alt="Hacktoberfest 2019" height="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2020.png" alt="Hacktoberfest 2020" height="150"/>
+		<img src="./README/images/hacktoberfest/hacktoberfest-2021.png" alt="Hacktoberfest 2021" height="150"/>
 	</p>
 </div>


### PR DESCRIPTION
# fix(readme): set height instead of width to align `Hacktoberfest` images

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P0 | S | 30-06-2022 | 30-06-2022 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" alt="Before - Hacktoberfest images with different sizes" src="https://user-images.githubusercontent.com/14045148/176777683-bcbf9c07-44b2-4711-8dc5-7ee54d4c2b08.png" /> | <img width="400" alt="After - Hacktoberfest images aligned with height" src="https://user-images.githubusercontent.com/14045148/176781021-f386f5d1-4a5a-4f4f-b2b0-8added71ff92.png" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Replace `width="150"` with `height="130"` on Hacktoberfest badge images to ensure consistent alignment
- Images had different aspect ratios, so fixed width caused uneven heights

## 📋 Changes Made

### Bug Fixes
- Change `width="150"` → `height="130"` on 3 Hacktoberfest badges (2019, 2020, 2021)

## 🧪 Tests

- [x] Verify Hacktoberfest images are aligned using `height` attribute
- [x] Verify images display at consistent size on GitHub profile

## 🔗 References

### Related Issues
- Closes #3
