### PR TITLE
feat(readme): update `GitHub` stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@
 					alt="Beatriz's GitHub Stats"/>
 			</a>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark&show_icons=true"
+				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
 			<a href="https://wakatime.com/@beatrizsmerino">

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@
 					alt="Beatriz's GitHub Stats"/>
 			</a>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&hide=html&theme=vue-dark&show_icons=true"
+				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
 			<a href="https://wakatime.com/@beatrizsmerino">

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@
 				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&hide=html&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
+			<a href="https://wakatime.com/@beatrizsmerino">
+				<img src="https://github-readme-stats.vercel.app/api/wakatime?username=beatrizsmerino&layout=compact&theme=vue-dark"
+					alt="Beatriz's GitHub Stats: Wakatime (last year)"/>
+			</a>
 		</p>
 	</div>
 </details>

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@
 	<div>
 		<p>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&theme=vue-dark&show_icons=true"
+				<img src="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats"/>
 			</a>
 			<a href="https://github.com/beatrizsmerino/">

--- a/README.md
+++ b/README.md
@@ -342,11 +342,11 @@
 	</summary>
 	<div>
 		<p>
-			<a href="https://github.com/beatrizsmerino/">
+			<a href="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true">
 				<img src="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats"/>
 			</a>
-			<a href="https://github.com/beatrizsmerino/">
+			<a href="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark">
 				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>

--- a/README.md
+++ b/README.md
@@ -343,12 +343,12 @@
 	<div>
 		<p>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&hide=html&theme=vue-dark&show_icons=true"
-					alt="Beatriz's GitHub Stats: Top programming languages"/>
-			</a>
-			<a href="https://github.com/beatrizsmerino/">
 				<img src="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats"/>
+			</a>
+			<a href="https://github.com/beatrizsmerino/">
+				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&hide=html&theme=vue-dark&show_icons=true"
+					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
 		</p>
 	</div>

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@
 					alt="Beatriz's GitHub Stats"/>
 			</a>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&theme=vue-dark&show_icons=true"
+				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
 			<a href="https://wakatime.com/@beatrizsmerino">

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@
 	<div>
 		<p>
 			<a href="https://github.com/beatrizsmerino/">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&hide=html&theme=vue-dark&show_icons=true"
+				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&hide=html&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
 			<a href="https://github.com/beatrizsmerino/">


### PR DESCRIPTION
# feat(readme): update `GitHub` stats

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 30-10-2023 | 30-10-2023 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" alt="Before - GitHub stats" src="https://github.com/beatrizsmerino/beatrizsmerino/assets/14045148/bf76e215-ae79-4e39-800a-71f75ec7d134" /> | <img width="400" alt="After - GitHub stats updated" src="https://github.com/beatrizsmerino/beatrizsmerino/assets/14045148/945a1445-6a1a-4846-96e1-7140204d058f" /> |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [x] New feature
- [ ] Improvement
- [ ] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Reorder stats: move general GitHub statistics to the top, most used languages below
- Add WakaTime card to show coding activity (last year)
- Switch top languages card to compact layout and increase from default to top 10
- Add `show` parameter to display additional stats (`reviews`, `discussions_started`, `discussions_answered`, `prs_merged`, `prs_merged_percentage`)
- Use direct stats URLs instead of GitHub profile links

## 📋 Changes Made

### New Features
- Add WakaTime coding activity card linked to `wakatime.com/@beatrizsmerino`
- Add `show` parameter with `reviews`, `discussions_started`, `discussions_answered`, `prs_merged` and `prs_merged_percentage`

### Improvements
- Reorder cards: general stats first, top languages second, WakaTime third
- Switch top languages to compact layout (`layout=compact`) with top 10 (`langs_count=10`)
- Replace GitHub profile links with direct stats image URLs
- Remove unnecessary `show_icons` parameter from top languages card

## 🧪 Tests

- [x] Verify GitHub stats section renders correctly on profile page
- [x] Verify stats images load without errors

## 🔗 References

### Documentation
- https://github.com/anuraghazra/github-readme-stats
- https://wakatime.com/@beatrizsmerino
