### PR TITLE
hotfix(2.12.1): fix `github-readme-stats` broken images

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,12 +374,12 @@
 	</summary>
 	<div>
 		<p>
-			<a href="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true">
-				<img src="https://github-readme-stats.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true"
+			<a href="https://github-readme-stats-beatrizsmerino.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true">
+				<img src="https://github-readme-stats-beatrizsmerino.vercel.app/api?username=beatrizsmerino&count_private=true&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&theme=vue-dark&show_icons=true"
 					alt="Beatriz's GitHub Stats"/>
 			</a>
-			<a href="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark">
-				<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark"
+			<a href="https://github-readme-stats-beatrizsmerino.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark">
+				<img src="https://github-readme-stats-beatrizsmerino.vercel.app/api/top-langs/?username=beatrizsmerino&layout=compact&langs_count=10&theme=vue-dark"
 					alt="Beatriz's GitHub Stats: Top programming languages"/>
 			</a>
     	</p>
@@ -391,7 +391,7 @@
 		</p>
     	<p>
     		<a href="https://wakatime.com/@beatrizsmerino">
-    			<img src="https://github-readme-stats.vercel.app/api/wakatime?username=beatrizsmerino&layout=compact&theme=vue-dark"
+    			<img src="https://github-readme-stats-beatrizsmerino.vercel.app/api/wakatime?username=beatrizsmerino&layout=compact&theme=vue-dark"
     				alt="Beatriz's GitHub Stats: Wakatime (last year)"/>
     		</a>
     	</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "beatrizsmerino",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "beatrizsmerino",
-			"version": "2.12.0",
+			"version": "2.12.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@commitlint/cli": "^20.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"name": "beatrizsmerino",
 	"description": "Main repository to describe the GitHub profile",
 	"author": "beatrizsmerino@gmail.com",


### PR DESCRIPTION
# hotfix(2.12.1): fix `github-readme-stats` broken images

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 17-01-2026 | 17-01-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" alt="Broken stats image" src="https://github.com/user-attachments/assets/0447f3c4-8ec0-4c74-9110-b1e97734c620" /> | <img width="805" height="871" alt="Screenshot 2026-01-17 a las 20 32 18" src="https://github.com/user-attachments/assets/823f9dc3-0fcd-4972-b0d2-5aba943e7f95" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Fix broken stats images in profile README by deploying a personal Vercel instance of `github-readme-stats`
- Bump version from `2.12.0` to `2.12.1`

## 📋 Changes Made

### Bug Fixes
- Replace all `github-readme-stats.vercel.app` URLs with `github-readme-stats-beatrizsmerino.vercel.app`

### Version
- Bump version from `2.12.0` to `2.12.1`

## 🧪 Tests

- [x] Verify the new URL returns the stats image in the browser
- [x] Verify the image displays correctly in the profile README

## 🔗 References

### Related Issues
- Closes #101